### PR TITLE
Fixed address for removing level up damage

### DIFF
--- a/MSEA/178.2/Full Map Attack
+++ b/MSEA/178.2/Full Map Attack
@@ -6,15 +6,12 @@
 0162E172: // MsInterSectRect
 db EB
 
-027D78CE:
+027D78A6: // Remove level up damage that causes DC
 db EB
 
 [DISABLE]
 0162E172: //  75 ? 84 ? 0F ? ? ? ? 00 8B ? ? 8B
 db 75
 
-027D78CE: //  74 ? C7 87 ? ? 00 00 00 00 00 00 8B 0D 68 EA BA C4 04 FF
-//68 EA BA C4 04 FF [2 je above]
+027D78A6: //  74 ? C7 87 ? ? 00 00 00 00 00 00 8B 0D 
 db 74
-
-//I've only tested this script for 10 minutes , might be unsafe (08/16/2018)


### PR DESCRIPTION
027D78CE was the wrong address , updated to 027D78A6 with the new AoB.

Address is to remove level up damage which causes DC due to GFMA being incompatible with level up